### PR TITLE
refactor: change instances of name in project an dplaybook configurat…

### DIFF
--- a/src/models/configuration/playbook/playbookConfiguration.ts
+++ b/src/models/configuration/playbook/playbookConfiguration.ts
@@ -1,7 +1,7 @@
 export interface PlaybookConfiguration {
   isActive?: boolean;
   location: URL | string;
-  name: string;
+  playbookName: string;
   token?: string;
   templatesPath?: string;
 }

--- a/src/models/configuration/project/projectConfiguration.ts
+++ b/src/models/configuration/project/projectConfiguration.ts
@@ -2,7 +2,7 @@ import { SprintConfiguration } from "./sprintConfiguration";
 
 export interface ProjectConfiguration {
   isActive?: boolean;
-  name: string;
+  projectName: string;
   url: URL;
   token?: string;
   sprints?: SprintConfiguration[];

--- a/src/services/configuration/configurationService.ts
+++ b/src/services/configuration/configurationService.ts
@@ -3,15 +3,15 @@ import { OnlyRequire, PlaybookConfiguration, ProjectConfiguration } from "../../
 export interface ConfigurationService {
   getPlaybooks(): Promise<PlaybookConfiguration[]>;
   addPlaybook(options: PlaybookConfiguration): void;
-  updatePlaybook(options: OnlyRequire<PlaybookConfiguration, "name">): void;
-  removePlaybook(name: string): void;
-  selectPlaybook(name: string): void;
-  deselectPlaybook(name: string): void;
+  updatePlaybook(options: OnlyRequire<PlaybookConfiguration, "playbookName">): void;
+  removePlaybook(playbookName: string): void;
+  selectPlaybook(playbookName: string): void;
+  deselectPlaybook(playbookName: string): void;
 
   getProjects(): Promise<ProjectConfiguration[]>;
   addProject(options: ProjectConfiguration): void;
-  updateProject(options: OnlyRequire<ProjectConfiguration, "name">): void;
-  removeProject(name: string): void;
-  selectProject(name: string): void;
-  deselectProject(name: string): void;
+  updateProject(options: OnlyRequire<ProjectConfiguration, "projectName">): void;
+  removeProject(projectName: string): void;
+  selectProject(projectName: string): void;
+  deselectProject(projectName: string): void;
 }

--- a/src/services/configuration/storedConfigurationService.test.ts
+++ b/src/services/configuration/storedConfigurationService.test.ts
@@ -9,24 +9,24 @@ describe("File Configuration Service", () => {
   const logger = ServiceSimulator.createTestLogger();
 
   const newPlaybook: PlaybookConfiguration = {
-    name: "new playbook",
+    playbookName: "new playbook",
     location: "/my/local/playbook",
     templatesPath: "/my/local/playbook/templates",
   };
 
   const existingPlaybook: PlaybookConfiguration = {
-    name: "existing playbook",
+    playbookName: "existing playbook",
     location: new URL("https://www.github.com/projector-cli/projector-cli"),
     token: "projector token",
   };
 
   const newProject: ProjectConfiguration = {
-    name: "new playbook",
+    projectName: "new playbook",
     url: new URL("https://dev.azure.com"),
   };
 
   const existingProject: ProjectConfiguration = {
-    name: "existing playbook",
+    projectName: "existing playbook",
     url: new URL("https://www.github.com/projector-cli/projector-cli"),
     token: "projector token",
   };
@@ -144,7 +144,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.removePlaybook(newPlaybook.name);
+    await configurationService.removePlaybook(newPlaybook.playbookName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -156,7 +156,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.removePlaybook(newPlaybook.name);
+    await configurationService.removePlaybook(newPlaybook.playbookName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -169,7 +169,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.removePlaybook(newPlaybook.name);
+    await configurationService.removePlaybook(newPlaybook.playbookName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -182,7 +182,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.removePlaybook(existingPlaybook.name);
+    await configurationService.removePlaybook(existingPlaybook.playbookName);
 
     // Assert
     expect(storageService.write).toBeCalled();
@@ -196,7 +196,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.selectPlaybook(newPlaybook.name);
+    await configurationService.selectPlaybook(newPlaybook.playbookName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -208,7 +208,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.selectPlaybook(newPlaybook.name);
+    await configurationService.selectPlaybook(newPlaybook.playbookName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -221,7 +221,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.selectPlaybook(newPlaybook.name);
+    await configurationService.selectPlaybook(newPlaybook.playbookName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -234,7 +234,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.selectPlaybook(existingPlaybook.name);
+    await configurationService.selectPlaybook(existingPlaybook.playbookName);
 
     // Assert
     expect(storageService.write).toBeCalled();
@@ -248,7 +248,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.deselectPlaybook(newPlaybook.name);
+    await configurationService.deselectPlaybook(newPlaybook.playbookName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -260,7 +260,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.deselectPlaybook(newPlaybook.name);
+    await configurationService.deselectPlaybook(newPlaybook.playbookName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -273,7 +273,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.deselectPlaybook(newPlaybook.name);
+    await configurationService.deselectPlaybook(newPlaybook.playbookName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -286,7 +286,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.deselectPlaybook(existingPlaybook.name);
+    await configurationService.deselectPlaybook(existingPlaybook.playbookName);
 
     // Assert
     expect(storageService.write).toBeCalled();
@@ -470,7 +470,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.removeProject(newProject.name);
+    await configurationService.removeProject(newProject.projectName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -482,7 +482,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.removeProject(newProject.name);
+    await configurationService.removeProject(newProject.projectName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -495,7 +495,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.removeProject(newProject.name);
+    await configurationService.removeProject(newProject.projectName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -508,7 +508,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.removeProject(existingProject.name);
+    await configurationService.removeProject(existingProject.projectName);
 
     // Assert
     expect(storageService.write).toBeCalled();
@@ -522,7 +522,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.selectProject(newProject.name);
+    await configurationService.selectProject(newProject.projectName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -534,7 +534,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.selectProject(newProject.name);
+    await configurationService.selectProject(newProject.projectName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -547,7 +547,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.selectProject(newProject.name);
+    await configurationService.selectProject(newProject.projectName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -560,7 +560,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.selectProject(existingProject.name);
+    await configurationService.selectProject(existingProject.projectName);
 
     // Assert
     expect(storageService.write).toBeCalled();
@@ -574,7 +574,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.deselectProject(newProject.name);
+    await configurationService.deselectProject(newProject.projectName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -586,7 +586,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.deselectProject(newProject.name);
+    await configurationService.deselectProject(newProject.projectName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -599,7 +599,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.deselectProject(newProject.name);
+    await configurationService.deselectProject(newProject.projectName);
 
     // Assert
     expect(storageService.write).not.toBeCalled();
@@ -612,7 +612,7 @@ describe("File Configuration Service", () => {
     const configurationService = new StoredConfigurationService(storageService, logger);
 
     // Act
-    await configurationService.deselectProject(existingProject.name);
+    await configurationService.deselectProject(existingProject.projectName);
 
     // Assert
     expect(storageService.write).toBeCalled();

--- a/src/services/configuration/storedConfigurationService.ts
+++ b/src/services/configuration/storedConfigurationService.ts
@@ -41,15 +41,15 @@ export class StoredConfigurationService implements ConfigurationService {
    */
   public async addPlaybook(options: PlaybookConfiguration): Promise<void> {
     const configuration = await this.getOrCreateConfiguration();
-    const matches = configuration.playbooks.filter((playbook) => playbook.name === options.name);
+    const matches = configuration.playbooks.filter((playbook) => playbook.playbookName === options.playbookName);
     if (matches.length === 1) {
       this.logger.warn(
-        `Tried to add new playbook ${options}\nBut playbook ${matches[0].name} already exists: ${matches[0]}`,
+        `Tried to add new playbook ${options}\nBut playbook ${matches[0].playbookName} already exists: ${matches[0]}`,
       );
     } else if (matches.length > 1) {
       this.logger.warn(
         `Something's wrong with your config file:\nTried to add new playbook ${options}\nBut playbooks ${matches
-          .map((match) => match.name)
+          .map((match) => match.playbookName)
           .join()} already exist: ${matches}`,
       );
     } else {
@@ -74,7 +74,7 @@ export class StoredConfigurationService implements ConfigurationService {
     const matches: PlaybookConfiguration[] = [];
     const others: PlaybookConfiguration[] = [];
     configuration.playbooks.forEach((playbook) =>
-      playbook.name === name ? matches.push(playbook) : others.push(playbook),
+      playbook.playbookName === name ? matches.push(playbook) : others.push(playbook),
     );
 
     if (matches.length !== 0) {
@@ -87,55 +87,55 @@ export class StoredConfigurationService implements ConfigurationService {
   /**
    * Selects a playbook to target with future commands.
    *
-   * @param {string} name The playbook to select.
+   * @param {string} playbookName The playbook to select.
    */
-  public async selectPlaybook(name: string): Promise<void> {
+  public async selectPlaybook(playbookName: string): Promise<void> {
     const configuration = await this.getOrCreateConfiguration();
-    const playbook = configuration.playbooks.find((playbook) => playbook.name === name);
+    const playbook = configuration.playbooks.find((playbook) => playbook.playbookName === playbookName);
     if (!playbook) {
-      this.logger.warn(`Couldn't find playbook ${name}.`);
+      this.logger.warn(`Couldn't find playbook ${playbookName}.`);
       return;
     }
     if (playbook.isActive) {
-      this.logger.log(`Playbook ${name} is already active.`);
+      this.logger.log(`Playbook ${playbookName} is already active.`);
       return;
     }
 
-    await this.updatePlaybook({ name, isActive: true });
+    await this.updatePlaybook({ playbookName, isActive: true });
   }
 
   /**
    * Deselects a playbook to target with future commands.
    *
-   * @param {string} name The playbook to deselect.
+   * @param {string} playbookName The playbook to deselect.
    */
-  public async deselectPlaybook(name: string): Promise<void> {
+  public async deselectPlaybook(playbookName: string): Promise<void> {
     const configuration = await this.getOrCreateConfiguration();
-    const playbook = configuration.playbooks.find((playbook) => playbook.name === name);
+    const playbook = configuration.playbooks.find((playbook) => playbook.playbookName === playbookName);
     if (!playbook) {
-      this.logger.warn(`Couldn't find playbook ${name}.`);
+      this.logger.warn(`Couldn't find playbook ${playbookName}.`);
       return;
     }
     if (!playbook.isActive) {
-      this.logger.log(`Playbook ${name} is already inactive.`);
+      this.logger.log(`Playbook ${playbookName} is already inactive.`);
       return;
     }
 
-    await this.updatePlaybook({ name, isActive: false });
+    await this.updatePlaybook({ playbookName, isActive: false });
   }
 
   /**
    * Updates the properties on a playbook.
    *
-   * @param {OnlyRequire<PlaybookConfiguration, "name">} options The options to update the playbook with.
+   * @param {OnlyRequire<PlaybookConfiguration, "playbookName">} options The options to update the playbook with.
    * Besides name, all arguments are optional.
    */
-  public async updatePlaybook(options: OnlyRequire<PlaybookConfiguration, "name">): Promise<void> {
+  public async updatePlaybook(options: OnlyRequire<PlaybookConfiguration, "playbookName">): Promise<void> {
     const configuration = await this.getOrCreateConfiguration();
     const matches: PlaybookConfiguration[] = [];
     const others: PlaybookConfiguration[] = [];
     configuration.playbooks.forEach((playbook) =>
-      playbook.name === options.name ? matches.push(playbook) : others.push(playbook),
+      playbook.playbookName === options.playbookName ? matches.push(playbook) : others.push(playbook),
     );
 
     if (matches.length === 1) {
@@ -151,11 +151,11 @@ export class StoredConfigurationService implements ConfigurationService {
     } else if (matches.length > 1) {
       this.logger.warn(
         `Something's wrong with your config file:\nTried to update playbook ${options}\nBut multiple playbooks ${matches
-          .map((match) => match.name)
+          .map((match) => match.playbookName)
           .join()} found: ${matches}`,
       );
     } else {
-      this.logger.warn(`No playbook named ${options.name} found.`);
+      this.logger.warn(`No playbook named ${options.playbookName} found.`);
     }
   }
 
@@ -185,15 +185,15 @@ export class StoredConfigurationService implements ConfigurationService {
    */
   public async addProject(options: ProjectConfiguration): Promise<void> {
     const configuration = await this.getOrCreateConfiguration();
-    const matches = configuration.projects.filter((project) => project.name === options.name);
+    const matches = configuration.projects.filter((project) => project.projectName === options.projectName);
     if (matches.length === 1) {
       this.logger.warn(
-        `Tried to add new project ${options}\nBut project ${matches[0].name} already exists: ${matches[0]}`,
+        `Tried to add new project ${options}\nBut project ${matches[0].projectName} already exists: ${matches[0]}`,
       );
     } else if (matches.length > 1) {
       this.logger.warn(
         `Something's wrong with your config file:\nTried to add new project ${options}\nBut projects ${matches
-          .map((match) => match.name)
+          .map((match) => match.projectName)
           .join()} already exist: ${matches}`,
       );
     } else {
@@ -206,13 +206,15 @@ export class StoredConfigurationService implements ConfigurationService {
   /**
    * Removes a project from the configuration.
    *
-   * @param {string} name The name of the project to remove.
+   * @param {string} projectName The name of the project to remove.
    */
-  public async removeProject(name: string): Promise<void> {
+  public async removeProject(projectName: string): Promise<void> {
     const configuration = await this.getOrCreateConfiguration();
     const matches: ProjectConfiguration[] = [];
     const others: ProjectConfiguration[] = [];
-    configuration.projects.forEach((project) => (project.name === name ? matches.push(project) : others.push(project)));
+    configuration.projects.forEach((project) =>
+      project.projectName === projectName ? matches.push(project) : others.push(project),
+    );
 
     if (matches.length !== 0) {
       configuration.projects = others;
@@ -224,57 +226,57 @@ export class StoredConfigurationService implements ConfigurationService {
   /**
    * Selects a project to target with future commands.
    *
-   * @param {string} name The project to select.
+   * @param {string} projectName The project to select.
    */
-  public async selectProject(name: string): Promise<void> {
+  public async selectProject(projectName: string): Promise<void> {
     const configuration = await this.getOrCreateConfiguration();
-    const project = configuration.projects.find((project) => project.name === name);
+    const project = configuration.projects.find((project) => project.projectName === projectName);
     if (!project) {
-      this.logger.warn(`Couldn't find project ${name}.`);
+      this.logger.warn(`Couldn't find project ${projectName}.`);
       return;
     }
     if (project.isActive) {
-      this.logger.log(`Project ${name} is already active.`);
+      this.logger.log(`Project ${projectName} is already active.`);
       return;
     }
 
-    await this.updateProject({ name, isActive: true });
+    await this.updateProject({ projectName, isActive: true });
   }
 
   /**
    * Deselects a project to target with future commands.
    *
-   * @param {string} name The project to deselect.
+   * @param {string} projectName The project to deselect.
    */
-  public async deselectProject(name: string): Promise<void> {
+  public async deselectProject(projectName: string): Promise<void> {
     const configuration = await this.storageService.read(FileConstants.configFileName);
     if (configuration) {
-      const project = configuration.projects.find((project) => project.name === name);
+      const project = configuration.projects.find((project) => project.projectName === projectName);
       if (!project) {
-        this.logger.warn(`Couldn't find project ${name}.`);
+        this.logger.warn(`Couldn't find project ${projectName}.`);
         return;
       }
       if (!project.isActive) {
-        this.logger.log(`Project ${name} is already inactive.`);
+        this.logger.log(`Project ${projectName} is already inactive.`);
         return;
       }
 
-      await this.updateProject({ name, isActive: false });
+      await this.updateProject({ projectName, isActive: false });
     }
   }
 
   /**
    * Updates the properties on a project.
    *
-   * @param {OnlyRequire<ProjectConfiguration, "name">} options The options to update the project with.
+   * @param {OnlyRequire<ProjectConfiguration, "projectName">} options The options to update the project with.
    * Besides name, all arguments are optional.
    */
-  public async updateProject(options: OnlyRequire<ProjectConfiguration, "name">): Promise<void> {
+  public async updateProject(options: OnlyRequire<ProjectConfiguration, "projectName">): Promise<void> {
     const configuration = await this.getOrCreateConfiguration();
     const matches: ProjectConfiguration[] = [];
     const others: ProjectConfiguration[] = [];
     configuration.projects.forEach((project) =>
-      project.name === options.name ? matches.push(project) : others.push(project),
+      project.projectName === options.projectName ? matches.push(project) : others.push(project),
     );
 
     if (matches.length === 1) {
@@ -290,11 +292,11 @@ export class StoredConfigurationService implements ConfigurationService {
     } else if (matches.length > 1) {
       this.logger.warn(
         `Something's wrong with your config file:\nTried to update project ${options}\nBut multiple projects ${matches
-          .map((match) => match.name)
+          .map((match) => match.projectName)
           .join()} found: ${matches}`,
       );
     } else {
-      this.logger.warn(`No project named ${options.name} found.`);
+      this.logger.warn(`No project named ${options.projectName} found.`);
     }
   }
 


### PR DESCRIPTION
## What did you implement:

`name` is a reserved keyword in Commander.js, the library that we're using to provide the CLI experience.

## How did you implement it:

Changed instances of name to projectName and playbookName.

## Todos:

_**Note: Run `npm run check` to run all validation checks on proposed changes**_

- [X] Ensure there are no lint errors
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Write tests and confirm existing functionality is not broken
       **Validate via `npm test`**
- ~~[ ] Write documentation~~ No changes to documentation in this PR.
- [X] Pull request title and commit message follows [the conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#summary)
- [X] Provide verification config / commands / resources
- ~~[ ] Requested reviews from at least 2 individuals~~ I'll merge this and it can be reviewed as part of the other refactor.
- [X] Assigned PR to myself
- ~~[ ] Added PR to correct project~~ No project
- [X] This is ready for review

**_Is it a breaking change?:_** NO